### PR TITLE
ar71xx-generic: drop alfa tube2h and hornet-ub

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -22,14 +22,6 @@ device('alfa-network-ap121f', 'ap121f', {
 	factory = false,
 })
 
-device('alfa-network-hornet-ub', 'hornet-ub', {
-	profile = 'HORNETUB',
-	aliases = { 'alfa-network-ap121', 'alfa-network-ap121u' },
-})
-
-device('alfa-network-tube2h', 'tube2h-8M', {
-	profile = 'TUBE2H8M',
-})
 device('alfa-network-n2-n5', 'alfa-nx', {
 	profile = 'ALFANX',
 })


### PR DESCRIPTION
Their kernel partition is too small, the OpenWrt build system is unable to create an image